### PR TITLE
Don't attempt to parse empty response body

### DIFF
--- a/lib/vercel/api.ts
+++ b/lib/vercel/api.ts
@@ -96,5 +96,9 @@ async function fetchVercelApi(
     );
   }
 
+  if (res.status === 201) {
+    return;
+  }
+
   return await res.json();
 }


### PR DESCRIPTION
This PR updates the API client to skip parsing the JSON response of an empty 201 response body.