### PR TITLE
fix billing item name

### DIFF
--- a/data/mock-billing-data.ts
+++ b/data/mock-billing-data.ts
@@ -55,7 +55,7 @@ export async function mockBillingData(
       return {
         resourceId: resource.id,
         billingPlanId: resource.billingPlan.id,
-        name: `${resource.name}: ${u.name}`,
+        name: u.name,
         price: pricing.price.toFixed(2),
         units: u.units,
         quantity: u.periodValue,


### PR DESCRIPTION
fix billing item name as it should match the metric name. Otherwise it's impossible to match usage with billing for a specific metric

![Screenshot 2024-06-19 at 09 28 17](https://github.com/vercel/example-marketplace-integration/assets/1736925/3346926d-5428-43c6-b68c-10c5560a800d)
