### PR TITLE
Add environment overrides to allow testing new env secrets feature

### DIFF
--- a/app/dashboard/resources/[resourceId]/actions.ts
+++ b/app/dashboard/resources/[resourceId]/actions.ts
@@ -54,10 +54,16 @@ export async function rotateCredentialsAction(
     throw new Error(`Unknown resource '${formData.get("resourceId")}`);
   }
 
+  const currentDate = new Date().toISOString();
+
   await updateSecrets(session.installation_id, resource.id, [
     {
       name: "TOP_SECRET",
-      value: `birds aren't real (${new Date().toISOString()})`,
+      value: `birds aren't real (${currentDate})`,
+      environmentOverrides: resource.productId === 'with-env-override' ? {
+          'production': `birds ARE real (${currentDate})`,
+          'preview': `birds might be real (${currentDate})`,
+      } : undefined,
     },
   ]);
 }

--- a/lib/partner/index.ts
+++ b/lib/partner/index.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import {
+import type {
   BillingPlan,
   GetBillingPlansResponse,
   GetResourceResponse,
@@ -157,13 +157,19 @@ export async function provisionResource(
   await kv.lpush(`${installationId}:resources`, resource.id);
   await updateInstallation(installationId, request.billingPlanId);
 
+  const currentDate = new Date().toISOString();
+
   return {
     ...resource,
 
     secrets: [
       {
         name: "TOP_SECRET",
-        value: `birds aren't real (${new Date().toISOString()})`,
+        value: `birds aren't real (${currentDate})`,
+        environmentOverrides: resource.productId === 'with-env-override' ? {
+            'production': `birds ARE real (${currentDate})`,
+            'preview': `birds ARE real (${currentDate})`,
+        } : undefined,
       },
     ],
   };

--- a/lib/vercel/marketplace-api.ts
+++ b/lib/vercel/marketplace-api.ts
@@ -55,7 +55,7 @@ export async function getAccountInfo(
 export async function updateSecrets(
   installationId: string,
   resourceId: string,
-  secrets: { name: string; value: string }[]
+  secrets: { name: string; value: string; environmentOverrides?: Record<string, string> }[]
 ): Promise<void> {
   const resource = await getResource(installationId, resourceId);
 

--- a/lib/vercel/schemas.ts
+++ b/lib/vercel/schemas.ts
@@ -238,8 +238,14 @@ export type ProvisionResourceRequest = z.infer<
   typeof provisionResourceRequestSchema
 >;
 
+const environmentOverrideTargets = z.enum(['production', 'preview', 'development']);
+
 export const provisionResourceResponseSchema = resourceSchema.extend({
-  secrets: z.array(z.object({ name: z.string(), value: z.string() })),
+  secrets: z.array(z.object({
+    name: z.string(),
+    value: z.string(),
+    environmentOverrides: z.record(environmentOverrideTargets, z.string()).optional(),
+  })),
 });
 
 export type ProvisionResourceResponse = z.infer<


### PR DESCRIPTION
We're implementing the ability to override secrets for specific (default, not custom) environments that will apply for all projects connected to a given resource, and will apply the same across all deployments in that environment for those resources. This PR allows us to have a test version of those secrets being applied for just a specific product, as this feature is not fully live and available for all integrations yet.