### PR TITLE
Fix expiration check & clarify distinct errors

### DIFF
--- a/app/v1/installations/[installationId]/resource-transfer-requests/[transferId]/complete/route.ts
+++ b/app/v1/installations/[installationId]/resource-transfer-requests/[transferId]/complete/route.ts
@@ -33,8 +33,11 @@ export const POST = withAuth(
 
         // is the claim in a state that can be completed?
         const now = new Date().getTime();
-        if (matchingClaim.status !== 'verified' || matchingClaim.expiration > now) {
-            return NextResponse.json(buildError('conflict', 'Operation failed because of a conflict with the current state of the resource'), { status: 409 });
+        if (matchingClaim.status !== 'verified') {
+            return NextResponse.json(buildError('conflict', 'The provided transfer request has not been verified for the target installation'), { status: 409 });
+        }
+        if(matchingClaim.expiration < now) {
+            return NextResponse.json(buildError('conflict', 'The provided transfer request has expired'), { status: 409 });
         }
 
         const getPipeline = kv.pipeline();

--- a/app/v1/installations/[installationId]/resource-transfer-requests/[transferId]/verify/route.ts
+++ b/app/v1/installations/[installationId]/resource-transfer-requests/[transferId]/verify/route.ts
@@ -22,8 +22,11 @@ export const POST = withAuth(
 
         // is the claim in a state that can be verified?
         const now = new Date().getTime();
-        if (matchingClaim.status === 'complete' || matchingClaim.expiration > now) {
-            return NextResponse.json(buildError('conflict', 'Operation failed because of a conflict with the current state of the resource'), { status: 409 });
+        if (matchingClaim.status === 'complete') {
+            return NextResponse.json(buildError('conflict', 'The provided transfer request has already been completed'), { status: 409 });
+        }
+        if (matchingClaim.expiration < now) {
+            return NextResponse.json(buildError('conflict', 'The provided transfer request has expired'), { status: 409 });
         }
 
         const targetInstallations = new Set(matchingClaim.targetInstallationIds);


### PR DESCRIPTION
The expiration check is currently inverted. This fix flips it to properly check if a transfer has expired or not.

Additionally, expiration has been separated from the valid state check to provide more granular error responses.