### PR TITLE
Use individual redis calls instead of pipeline to simplify implementation

### DIFF
--- a/lib/partner/index.ts
+++ b/lib/partner/index.ts
@@ -208,6 +208,20 @@ export async function updateResource(
   return nextResource;
 }
 
+export async function transferResource(installationId: string, resourceId: string, targetInstallationId: string): Promise<void> {
+  const resource = await getResource(installationId, resourceId);
+
+  if (!resource) {
+    throw new Error(`Cannot find resource ${resourceId}`);
+  }
+
+  await kv.set(
+    `${targetInstallationId}:resource:${resourceId}`,
+    serializeResource(resource),
+  );
+  await kv.del(`${installationId}:resource:${resourceId}`);
+}
+
 export async function updateResourceNotification(
   installationId: string,
   resourceId: string,


### PR DESCRIPTION
The implementation using pipelines for transfers is throwing errors failing to find IDs. Since this path is low-volume & the number of resources being transferred from a claim transfer is expected to be low as well, the pipeline optimization is unlikely to matter. Typical use cases will transfer 1, maybe 2 resources per transfer request.