### PR TITLE
Optimize marketplace plan listing

### DIFF
--- a/lib/partner/index.ts
+++ b/lib/partner/index.ts
@@ -290,6 +290,10 @@ export async function listResources(
   };
 }
 
+async function getResourceCount(installationId: string): Promise<number> {
+  return kv.llen(`${installationId}:resources`);
+}
+
 export async function getResource(
   installationId: string,
   resourceId: string,
@@ -492,10 +496,10 @@ export async function getInstallationBillingPlans(
   installationId: string,
   _experimental_metadata?: Record<string, unknown>,
 ): Promise<GetBillingPlansResponse> {
-  const resources = await listResources(installationId);
+  const resourceCount = await getResourceCount(installationId);
   return {
     plans:
-      resources.resources.length > 2
+      resourceCount > 2
         ? billingPlans.filter((p) => p.paymentMethodRequired)
         : billingPlans,
   };
@@ -506,10 +510,10 @@ export async function getProductBillingPlans(
   installationId: string,
   _experimental_metadata?: Record<string, unknown>,
 ): Promise<GetBillingPlansResponse> {
-  const resources = await listResources(installationId);
+  const resourceCount = await getResourceCount(installationId);
   return {
     plans:
-      resources.resources.length > 2
+      resourceCount > 2
         ? billingPlans.filter((p) => p.paymentMethodRequired)
         : billingPlans,
   };


### PR DESCRIPTION
## Summary
- use Redis list length instead of loading every resource to determine plan availability
- apply the constant-time lookup to installation and product plan listing

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm lint` (fails on pre-existing formatting in `.vercel/project.json`)

> 🤖 Drafted by OpenCode (`vercel/openai/gpt-5.6-terra-fast`) on Marc's behalf