### PR TITLE
Maintain resource indexes during transfers

### DIFF
--- a/app/v1/installations/[installationId]/resource-transfer-requests/[transferId]/accept/route.ts
+++ b/app/v1/installations/[installationId]/resource-transfer-requests/[transferId]/accept/route.ts
@@ -64,13 +64,15 @@ export const POST = withAuth(
       );
     }
 
-    for (const resourceId of matchingClaim.resourceIds) {
-      transferResource(
-        matchingClaim.sourceInstallationId,
-        resourceId,
-        params.installationId,
-      );
-    }
+    await Promise.all(
+      matchingClaim.resourceIds.map((resourceId) =>
+        transferResource(
+          matchingClaim.sourceInstallationId,
+          resourceId,
+          params.installationId,
+        ),
+      ),
+    );
 
     await setTransferRequest({
       ...matchingClaim,

--- a/lib/partner/index.ts
+++ b/lib/partner/index.ts
@@ -221,11 +221,16 @@ export async function transferResource(
     throw new Error(`Cannot find resource ${resourceId}`);
   }
 
-  await kv.set(
+  const pipeline = kv.pipeline();
+  pipeline.set(
     `${targetInstallationId}:resource:${resourceId}`,
     serializeResource(resource),
   );
-  await kv.del(`${installationId}:resource:${resourceId}`);
+  pipeline.del(`${installationId}:resource:${resourceId}`);
+  pipeline.lrem(`${installationId}:resources`, 0, resourceId);
+  pipeline.lrem(`${targetInstallationId}:resources`, 0, resourceId);
+  pipeline.lpush(`${targetInstallationId}:resources`, resourceId);
+  await pipeline.exec();
 }
 
 export async function updateResourceNotification(


### PR DESCRIPTION
## Summary
- remove transferred resources from the source installation index
- add transferred resources to the target installation index without duplicates
- await resource moves before marking a transfer request complete

This keeps the `LLEN`-based plan availability count aligned with transferred resources.

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm lint` (fails on pre-existing formatting in `.vercel/project.json`)

> 🤖 Drafted by OpenCode (`vercel/openai/gpt-5.6-terra-fast`) on Marc's behalf