### PR TITLE
Compare the webhook signature in constant time

### DIFF
--- a/app/webhook/route.ts
+++ b/app/webhook/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request): Promise<Response> {
   const rawBodyBuffer = Buffer.from(rawBody, "utf-8");
   const bodySignature = sha1(rawBodyBuffer, env.INTEGRATION_CLIENT_SECRET);
 
-  if (bodySignature !== req.headers.get("x-vercel-signature")) {
+  if (!signaturesMatch(bodySignature, req.headers.get("x-vercel-signature"))) {
     return Response.json({
       code: "invalid_signature",
       error: "signature didn't match",
@@ -193,6 +193,26 @@ function sha1(data: Buffer, secret: string): string {
     .createHmac("sha1", secret)
     .update(new Uint8Array(data))
     .digest("hex");
+}
+
+/**
+ * Compare the computed signature with the one on the request in constant time.
+ *
+ * `===` on strings stops at the first differing byte, so how long the
+ * comparison takes depends on how many leading characters were correct. That
+ * turns a 40-character search space into a 40-step one, guessed a character at
+ * a time. `crypto.timingSafeEqual` always reads both buffers to the end.
+ *
+ * It throws when the two buffers differ in length, so the length is checked
+ * first. That check is not constant time, but the length of a hex digest is
+ * fixed and public — it reveals nothing an attacker does not already know.
+ */
+function signaturesMatch(expected: string, provided: string | null): boolean {
+  if (provided === null) return false;
+  const a = Buffer.from(expected, "utf-8");
+  const b = Buffer.from(provided, "utf-8");
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(new Uint8Array(a), new Uint8Array(b));
 }
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## The change

`app/webhook/route.ts:22` compares the computed HMAC with the one on the request using `!==`:

```ts
const bodySignature = sha1(rawBodyBuffer, env.INTEGRATION_CLIENT_SECRET);

if (bodySignature !== req.headers.get("x-vercel-signature")) {
```

String `!==` short-circuits at the first differing byte, so how long the comparison takes depends on how many leading characters were correct. That turns guessing a 40-character hex digest from a 16^40 problem into a 40-step one, recovered a character at a time.

This swaps it for `crypto.timingSafeEqual`, which always reads both buffers to the end. `timingSafeEqual` throws when the buffers differ in length, so the length is compared first — that check is not constant time, but a hex digest's length is fixed and public, so it reveals nothing.

Behaviour is identical for every valid and every invalid signature. Only the timing changes.

## Why this repo specifically

It is the reference an integration partner starts from. A signature check copied out of here is a signature check running in production somewhere else, and this is the line people copy verbatim.

The margins are narrower over a network than in a microbenchmark, which is the usual and fair objection. The reason to fix it anyway is that the constant-time version costs nothing — same file, same control flow, one helper — and nobody reading the example later has to work out whether their own deployment is the one where the margin is wide enough.

## Test plan

- [x] `biome check app/webhook/route.ts` clean, using the `^1.9.4` pinned in `package.json`.
- [x] Diff limited to one file: the comparison and one new helper. No dependency change — `crypto` is already imported at the top of this file.
- [x] Both branches walked by hand: a `null` header short-circuits before `Buffer.from`, a length mismatch returns `false` without calling `timingSafeEqual`, and a matching signature returns `true`.

## Two things I noticed but did not change

Happy to fold either in if you want them, or to leave them.

1. **The rejection returns `200`.** `Response.json({ code: "invalid_signature" })` with no status sends HTTP 200 with a JSON body. A caller with a bad signature gets a success status — `{ status: 401 }` would be the conventional answer, but it changes the contract, so it seemed wrong to bundle it into a security fix.

2. **`lib/vercel/auth.ts:49`** calls `jwtVerify(token, JWKS)` with no `algorithms` option. `jose` is not vulnerable to the classic `alg: none` and RS256→HS256 confusions the way some libraries are, so this is hardening rather than a bug — `{ algorithms: ["RS256"] }` pins it explicitly.

---

For context on how I found it: I maintain [a set of ESLint security plugins](https://github.com/ofri-peretz/eslint) and run them across public repositories to find real defects and, just as often, false positives in my own rules. This repository produced five findings; three were my bugs and are fixed upstream. This one was real.